### PR TITLE
BC-52 - OPS-2491 - Add OAuth with Hydra to the automatic Deployment

### DIFF
--- a/ansible/group_vars/all/hydra.yml
+++ b/ansible/group_vars/all/hydra.yml
@@ -1,0 +1,3 @@
+HYDRA_DNS_PREFIX: oauth-
+HYDRA_IMAGE_NAME: oryd/hydra
+HYDRA_IMAGE_TAG: v1.2.1-alpine

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -13,6 +13,7 @@
     - dof_mailcatcher
     - maildrop
     - storage
+    - hydra
     - dof_etherpad_nginx
     - dof_etherpad
     - schulcloud-server

--- a/ansible/roles/hydra/tasks/main.yml
+++ b/ansible/roles/hydra/tasks/main.yml
@@ -1,0 +1,44 @@
+  - name: Service
+    community.kubernetes.k8s:
+      kubeconfig: ~/.kube/config 
+      namespace: "{{ NAMESPACE }}"
+      template: svc.yml.j2
+      
+  - name: Ingress
+    community.kubernetes.k8s:
+      kubeconfig: ~/.kube/config 
+      namespace: "{{ NAMESPACE }}"
+      template: ingress.yml.j2
+      
+  - name: Configmap
+    community.kubernetes.k8s:
+      kubeconfig: ~/.kube/config 
+      namespace: "{{ NAMESPACE }}"
+      template: configmap.yml.j2
+      
+  - name: Secret
+    community.kubernetes.k8s:
+      kubeconfig: ~/.kube/config 
+      namespace: "{{ NAMESPACE }}"
+      template: secret.yml.j2
+    when: ONEPASSWORD is undefined or ONEPASSWORD is defined and not ONEPASSWORD
+      
+  - name: Secred by 1Password
+    community.kubernetes.k8s:
+      kubeconfig: ~/.kube/config 
+      namespace: "{{ NAMESPACE }}"
+      template: onepassword.yml.j2
+    when: ONEPASSWORD is defined and ONEPASSWORD|bool
+      
+  - name: Job
+    community.kubernetes.k8s:
+      kubeconfig: ~/.kube/config 
+      namespace: "{{ NAMESPACE }}"
+      template: job.yml.j2
+      
+  - name: Deployment
+    community.kubernetes.k8s:
+      kubeconfig: ~/.kube/config 
+      namespace: "{{ NAMESPACE }}"
+      template: deployment.yml.j2
+      

--- a/ansible/roles/hydra/templates/configmap.yml.j2
+++ b/ansible/roles/hydra/templates/configmap.yml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hydra-configmap
+  namespace: {{ NAMESPACE }}
+  labels:
+    app: hydra
+data:
+  
+  CORS_ENABLED: "true"
+  CORS_ALLOWED_METHODS: "POST,GET,PUT,DELETE"
+  #LOG_LEVEL: "debug"
+  URLS_SELF_ISSUER: "https://{{ HYDRA_DNS_PREFIX }}{{ DOMAIN }}"
+  URLS_CONSENT: "https://{{ DOMAIN }}/oauth2/consent"
+  URLS_LOGIN: https://{{ DOMAIN }}/oauth2/login
+  SERVE_TLS_ALLOW_TERMINATION_FROM: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+  OIDC_SUBJECT_IDENTIFIERS_ENABLED: "public,pairwise"
+  SC_FRONTEND: "https://{{ DOMAIN }}"
+  

--- a/ansible/roles/hydra/templates/deployment.yml.j2
+++ b/ansible/roles/hydra/templates/deployment.yml.j2
@@ -51,7 +51,7 @@ spec:
         resources:
           limits:
             cpu: "1000m"
-            memory: "{{ HYDRA_MEM_MAX|default(1Gi, true) }}"
+            memory: "{{ HYDRA_MEM_MAX|default("1Gi", true) }}"
           requests:
             cpu: "100m"
-            memory: "{{ HYDRA_MEM_MIN|default(128Mi, true) }}"
+            memory: "{{ HYDRA_MEM_MIN|default("128Mi", true) }}"

--- a/ansible/roles/hydra/templates/deployment.yml.j2
+++ b/ansible/roles/hydra/templates/deployment.yml.j2
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hydra-deployment
+  namespace: {{ NAMESPACE }}
+  labels:
+    app: hydra
+spec:
+  replicas: 1
+  replicas: {{ HYDRA_REPLICAS|default(1, true) }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: hydra
+  template:
+    metadata:
+      labels:
+        app: hydra
+    spec:
+      containers:
+      - name: hydra
+        image: {{ HYDRA_IMAGE_NAME }}:{{ HYDRA_IMAGE_TAG }}
+        imagePullPolicy: Always
+        args: ["serve", "all"]
+        ports:
+        - containerPort: 4444
+        - containerPort: 4445
+        livenessProbe:
+          httpGet:
+            path: /health/alive
+            port: 4445
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 4445
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 5
+        envFrom:
+        - configMapRef:
+            name: hydra-configmap
+        - secretRef:
+            name: hydra-secret
+        resources:
+          limits:
+            cpu: "1000m"
+            memory: "{{ HYDRA_MEM_MAX|default(1Gi, true) }}"
+          requests:
+            cpu: "100m"
+            memory: "{{ HYDRA_MEM_MIN|default(128Mi, true) }}"

--- a/ansible/roles/hydra/templates/ingress.yml.j2
+++ b/ansible/roles/hydra/templates/ingress.yml.j2
@@ -1,0 +1,20 @@
+#jinja2: trim_blocks: "True", lstrip_blocks: "True"
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ NAMESPACE }}-hydra-ingress
+  namespace: {{ NAMESPACE }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+
+spec:
+  rules:
+  - host: {{ HYDRA_DNS_PREFIX }}{{ DOMAIN }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: hydra-svc
+          servicePort: 4444
+

--- a/ansible/roles/hydra/templates/job.yml.j2
+++ b/ansible/roles/hydra/templates/job.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hydra-migrate-db-job
+  namespace: {{ NAMESPACE }}
+  labels:
+    app: hydra
+spec:
+  template:
+    metadata:
+      labels:
+        app: hydra
+    spec:
+      containers:
+      - name: hydra-migrate
+        image: {{ HYDRA_IMAGE|default("oryd/hydra:v1.2.1-alpine", true) }}
+        imagePullPolicy: Always
+        args: ["migrate", "sql", "--yes", "$(DATABASE_URL)"]
+        envFrom:
+        - configMapRef:
+            name: hydra-configmap
+        - secretRef:
+            name: hydra-secret
+      restartPolicy: Never
+  backoffLimit: 3
+

--- a/ansible/roles/hydra/templates/onepassword.yml.j2
+++ b/ansible/roles/hydra/templates/onepassword.yml.j2
@@ -1,0 +1,9 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: hydra-secret
+  namespace: {{ NAMESPACE }}
+  labels:
+    app: hydra
+spec:
+  itemPath: "vaults/{{ VAULT }}/items/hydra"

--- a/ansible/roles/hydra/templates/secret.yml.j2
+++ b/ansible/roles/hydra/templates/secret.yml.j2
@@ -1,0 +1,18 @@
+#jinja2: trim_blocks: "True", lstrip_blocks: "True"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hydra-secret
+  labels:
+    app: hydra
+  namespace: {{ NAMESPACE }}
+type: Opaque
+data:
+  POSTGRES_PASSWORD: "{{ HYDRA_POSTGRES_PASSWORD | b64encode }}"
+  HYDRA_SYSTEM_SECRET: "{{ HYDRA_SYSTEM_SECRET | b64encode }}"
+  POSTGRES_HOST: "{{ HYDRA_POSTGRES_HOST | b64encode }}"
+  POSTGRES_USER: "{{ HYDRA_POSTGRES_USER | b64encode }}"
+  POSTGRES_DB: "{{ HYDRA_POSTGRES_DB | b64encode }}"
+  DATABASE_URL: "{{ HYDRA_DATABASE_URL | b64encode }}"
+  DSN: "{{ HYDRA_DATABASE_URL | b64encode }}"
+  OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT: "{{ HYDRA_OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT | b64encode }}"

--- a/ansible/roles/hydra/templates/svc.yml.j2
+++ b/ansible/roles/hydra/templates/svc.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hydra-svc
+  namespace: {{ NAMESPACE }}
+  labels:
+    app: hydra
+spec:
+  type: ClusterIP
+  ports:
+    - name: hydra4444
+      port: 4444
+      targetPort: 4444
+      protocol: TCP
+    - name: hydra4445
+      port: 4445
+      targetPort: 4445
+      protocol: TCP
+  selector:
+    app: hydra


### PR DESCRIPTION
# Description
Add OAuth with Hydra to the automatic Deployment

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2491
https://ticketsystem.hpi-schul-cloud.org/browse/BC-52

## Changes
Add OAuth with Hydra to the automatic Deployment

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
