### PR TITLE
BC-37 - BC-58 - configurable resource consumption

### DIFF
--- a/ansible/roles/dof_etherpad/templates/deployment.yml.j2
+++ b/ansible/roles/dof_etherpad/templates/deployment.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: etherpad
 spec:
-  replicas: {{ etherpad_REPLICAS|default(1, true) }}
+  replicas: {{ ETHERPAD_REPLICAS|default(1, true) }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/ansible/roles/dof_etherpad/templates/deployment.yml.j2
+++ b/ansible/roles/dof_etherpad/templates/deployment.yml.j2
@@ -48,11 +48,11 @@ spec:
           name: apikey
         resources:
           limits:
-            cpu: "1000m"
-            memory: "1Gi"
+            cpu: {{ ETHERPA_CPU_LIMITS|default("1000m", true) }}
+            memory: {{ ETHERPA_MEMORY_LIMITS|default("1Gi", true) }}
           requests:
-            cpu: "100m"
-            memory: "1Gi"
+            cpu: {{ ETHERPA_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ ETHERPA_MEMORY_REQUESTS|default("128Mi", true) }}
       volumes:
       - name: apikey
         configMap:

--- a/ansible/roles/dof_etherpad_nginx/templates/deployment.yml.j2
+++ b/ansible/roles/dof_etherpad_nginx/templates/deployment.yml.j2
@@ -39,11 +39,11 @@ spec:
           name: defaultconf
         resources:
           limits:
-            cpu: "1000m"
-            memory: "1Gi"
+            cpu: {{ ETHERPA_NGINX_CPU_LIMITS|default("1000m", true) }}
+            memory: {{ ETHERPA_NGINX_MEMORY_LIMITS|default("1Gi", true) }}
           requests:
-            cpu: "100m"
-            memory: "1Gi"
+            cpu: {{ ETHERPA_NGINX_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ ETHERPA_NGINX_MEMORY_REQUESTS|default("128Mi", true) }}
         livenessProbe:
           httpGet:
             path: /

--- a/ansible/roles/dof_etherpad_nginx/templates/deployment.yml.j2
+++ b/ansible/roles/dof_etherpad_nginx/templates/deployment.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: etherpad-nginx
 spec:
-  replicas: 1
+  replicas: {{ ETHERPAD_NGINX_REPLICAS|default(1, true) }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/ansible/roles/dof_mailcatcher/templates/deployment.yml.j2
+++ b/ansible/roles/dof_mailcatcher/templates/deployment.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: mailcatcher
 spec:
-  replicas: 1
+  replicas: {{ MAILCATCHER_REPLICAS|default(1, true) }}
   strategy:
     type: Recreate
   selector:
@@ -34,8 +34,8 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: "1000m"
-            memory: "256Mi"
+            cpu: {{ MAILCATCHER_CPU_LIMITS|default("1000m", true) }}
+            memory: {{ MAILCATCHER_MEMORY_LIMITS|default("256Mi", true) }}
           requests:
-            cpu: "100m"
-            memory: "256Mi"
+            cpu: {{ MAILCATCHER_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ MAILCATCHER_MEMORY_REQUESTS|default("256Mi", true) }}

--- a/ansible/roles/dof_mongo/templates/deployment.yml.j2
+++ b/ansible/roles/dof_mongo/templates/deployment.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: mongo
 spec:
-  replicas: 1
+  replicas: {{ MONGO_REPLICAS|default(1, true) }}
   strategy:
     type: Recreate
   revisionHistoryLimit: 4
@@ -44,11 +44,11 @@ spec:
           readOnly: false
         resources:
           limits:
-            cpu: "1000m"
-            memory: "512Mi"
+            cpu: {{ MONGO_CPU_LIMITS|default("2000m", true) }}
+            memory: {{ MONGO_MEMORY_LIMITS|default("1Gi", true) }}
           requests:
-            cpu: "100m"
-            memory: "512Mi"
+            cpu: {{ MONGO_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ MONGO_MEMORY_REQUESTS|default("256Mi", true) }}
       volumes:
       - name: mongodb-data-pv
         persistentVolumeClaim:

--- a/ansible/roles/dof_postgresql/templates/deployment.yml.j2
+++ b/ansible/roles/dof_postgresql/templates/deployment.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: postgres
 spec:
-  replicas: 1
+  replicas: {{ POSTGRES_REPLICAS|default(1, true) }}
   selector:
     matchLabels:
       app: postgres
@@ -35,11 +35,11 @@ spec:
           readOnly: false
         resources:
           limits:
-            cpu: "1000m"
-            memory: "256Mi"
+            cpu: {{ POSTGRES_CPU_LIMITS|default("2000m", true) }}
+            memory: {{ POSTGRES_MEMORY_LIMITS|default("1Gi", true) }}
           requests:
-            cpu: "100m"
-            memory: "256Mi"
+            cpu: {{ POSTGRES_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ POSTGRES_MEMORY_REQUESTS|default("256Mi", true) }}
       volumes:
       - name: postgres-data-pv 
         persistentVolumeClaim:

--- a/ansible/roles/dof_redis/templates/deployment.yml.j2
+++ b/ansible/roles/dof_redis/templates/deployment.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: redis
 spec:
-  replicas: 1
+  replicas: {{ REDIS_REPLICAS|default(1, true) }}
   strategy:
     type: Recreate
   selector:
@@ -35,11 +35,11 @@ spec:
           readOnly: false
         resources:
           limits:
-            cpu: "2000m"
-            memory: "128Mi"
+            cpu: {{ REDIS_CPU_LIMITS|default("2000m", true) }}
+            memory: {{ REDIS_MEMORY_LIMITS|default("128Mi", true) }}
           requests:
-            cpu: "100m"
-            memory: "128Mi"
+            cpu: {{ REDIS_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ REDIS_MEMORY_REQUESTS|default("128Mi", true) }}
       volumes:
       - name: redis-data-pv
         persistentVolumeClaim:

--- a/ansible/roles/maildrop/templates/deployment.yml.j2
+++ b/ansible/roles/maildrop/templates/deployment.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: maildrop
 spec:
-  replicas: 1
+  replicas: {{ MAILDROP_REPLICAS|default(1, true) }}
   strategy:
     type: Recreate
   selector:
@@ -30,8 +30,8 @@ spec:
             name: maildrop-secret
         resources:
           limits:
-            cpu: "1000m"
-            memory: "256Mi"
+            cpu: {{ MAILDROP_CPU_LIMITS|default("1000m", true) }}
+            memory: {{ MAILDROP_MEMORY_LIMITS|default("1Gi", true) }}
           requests:
-            cpu: "100m"
-            memory: "256Mi"
+            cpu: {{ MAILDROP_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ MAILDROP_MEMORY_REQUESTS|default("128Mi", true) }}

--- a/ansible/roles/storage/templates/deployment.yml.j2
+++ b/ansible/roles/storage/templates/deployment.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: storage
 spec:
-  replicas: 1
+  replicas: {{ STORAGE_REPLICAS|default(1, true) }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -48,11 +48,11 @@ spec:
           readOnly: false
         resources:
           limits:
-            cpu: "1000m"
-            memory: "512Mi"
+            cpu: {{ STORAGE_CPU_LIMITS|default("1000m", true) }}
+            memory: {{ STORAGE_MEMORY_LIMITS|default("1Gi", true) }}
           requests:
-            cpu: "100m"
-            memory: "512Mi"
+            cpu: {{ STORAGE_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ STORAGE_MEMORY_REQUESTS|default("128Mi", true) }}
       volumes:
       - name: storage-pv
         persistentVolumeClaim:


### PR DESCRIPTION
# Description
The resource consumption of MongoDB, PostgreSQL, redis, maildrop, mailcatcher, etherpad and storage are now configurable.

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-37
https://ticketsystem.hpi-schul-cloud.org/browse/BC-58

## Changes
Add ansible variables to make the resource consumption configurable.

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
