### PR TITLE
bc-266 added nuxt config path for api

### DIFF
--- a/ansible/roles/ingress/templates/ingress.yml.j2
+++ b/ansible/roles/ingress/templates/ingress.yml.j2
@@ -18,8 +18,11 @@ spec:
         backend:
           serviceName: client-svc
           servicePort: {{ CLIENT_PORT }}
-
       - path: /themes/{{ SC_THEME }}/favicon.png
+        backend:
+          serviceName: nuxtclient-svc
+          servicePort: {{ NUXTCLIENT_PORT }}
+      - path: /runtime.config.json
         backend:
           serviceName: nuxtclient-svc
           servicePort: {{ NUXTCLIENT_PORT }}


### PR DESCRIPTION
new path for nuxt - runtime.config.json contains currently ONLY the server api url and should not contain any more configs unless more is required to bootstarp the client 