### PR TITLE
BC-1202 - puth the stage as the same level at the parent/child tree as the instance group is

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -36,6 +36,8 @@ default
 nbc
 international
 thr
+develop
+reference
 
 [sc:vars]
 ansible_host=localhost


### PR DESCRIPTION
# Description
"You can change this behavior by setting the group variable ansible_group_priority to change the merge order for groups of the same level (after the parent/child order is resolved)." https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#how-variables-are-merged


## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-1202