### PR TITLE
BC-1386: Missing active state on Courses

### DIFF
--- a/ansible/group_vars/all/config.yml
+++ b/ansible/group_vars/all/config.yml
@@ -372,11 +372,6 @@ configuration_all:
     server: true
     client: true
     nuxtclient: false
-  LEGACY_COURSE_OVERVIEW_ENABLED:
-    value: "false"
-    server: false
-    client: true
-    nuxtclient: false
   FEATURE_ADMIN_TOGGLE_STUDENT_VISIBILITY_ENABLED:
     server: true
     client: true

--- a/ansible/group_vars/thr/instance_cfg.yml
+++ b/ansible/group_vars/thr/instance_cfg.yml
@@ -55,4 +55,3 @@ ENABLE_FILE_SECURITY_CHECK: "true"
 FILE_SECURITY_CHECK_SERVICE_URI: http://antivirus-webserver-svc:8080/scan/file
 
 ES_MERLIN_AUTH_URL: http://merlin.nibis.de/auth.php
-LEGACY_COURSE_OVERVIEW_ENABLED: "false"

--- a/ansible/host_vars/prod-brb/cfg.yml
+++ b/ansible/host_vars/prod-brb/cfg.yml
@@ -5,5 +5,3 @@ FEATURE_MATRIX_MESSENGER_ENABLED: "false"
 FEATURE_NEXBOARD_ENABLED: "true"
 
 ALERT_STATUS_URL: https://status.brandenburg.cloud
-# no rollout of new COURSE OVERVIEW to federal instances (THR, NBC, BRB)
-LEGACY_COURSE_OVERVIEW_ENABLED: "false"

--- a/ansible/host_vars/ref-brb/cfg.yml
+++ b/ansible/host_vars/ref-brb/cfg.yml
@@ -8,5 +8,3 @@ FEATURE_SKIP_FIRST_LOGIN_ENABLED: "true"
 ES_DOMAIN: https://mv-repo.schul-cloud.org
 DISPLAY_REQUEST_LEVEL: -1
 ALERT_STATUS_URL: https://status.brandenburg.cloud
-# no rollout of new COURSE OVERVIEW to federal instances (THR, NBC, BRB)
-LEGACY_COURSE_OVERVIEW_ENABLED: "false" 


### PR DESCRIPTION
# Description
Removing double course sidebar items and fixing the active state for "courses".
So the environment variable LEGACY_COURSE_OVERVIEW_ENABLED can be removed since it's not needed anymore.

## Links to Tickets or other pull requests
Ticket: https://ticketsystem.dbildungscloud.de/browse/BC-1386
Nuxt-Client PR: https://github.com/hpi-schul-cloud/nuxt-client/pull/2144
Legacy Client PR: https://github.com/hpi-schul-cloud/schulcloud-client/pull/2838

## Changes

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

## Deployment

## New Repos, NPM pakages or vendor scripts

## Screenshots of UI changes

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
https://ticketsystem.dbildungscloud.de/browse/BC-1386
https://github.com/hpi-schul-cloud/nuxt-client/pull/2144