### PR TITLE
Thr 28 docker static h5p files

### DIFF
--- a/.github/workflows/clean_workflow.yml
+++ b/.github/workflows/clean_workflow.yml
@@ -38,6 +38,7 @@ jobs:
          - antivirus_check_service
          - version-aggregator
          - dof_app_deploy
+         - h5p-staticfiles-server
     steps:
       - run: |
           echo "git_ref_name=${{ inputs.branch }}" >> $GITHUB_ENV

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,7 @@ jobs:
          - antivirus_check_service
          - version-aggregator
          - dof_app_deploy
+         - h5p-staticfiles-server
     steps:
       - run: |
           echo "git_ref_name=${{ inputs.branch }}" >> $GITHUB_ENV

--- a/.github/workflows/host.yml
+++ b/.github/workflows/host.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: hpi-schul-cloud/h5p-staticfiles-server
-          path: repo/schulcloud-calendar
+          path: repo/h5p-staticfiles-server
           token: ${{ secrets.token }}
           ref: ${{ env.H5P_STATICFILES_SERVER_VERSION }}
       - uses: actions/checkout@v3

--- a/.github/workflows/host.yml
+++ b/.github/workflows/host.yml
@@ -81,6 +81,12 @@ jobs:
           ref: ${{ env.SUPERHERO_DASHBOARD_VERSION }}
       - uses: actions/checkout@v3
         with:
+          repository: hpi-schul-cloud/h5p-staticfiles-server
+          path: repo/schulcloud-calendar
+          token: ${{ secrets.token }}
+          ref: ${{ env.H5P_STATICFILES_SERVER_VERSION }}
+      - uses: actions/checkout@v3
+        with:
           repository: hpi-schul-cloud/schulcloud-calendar
           path: repo/schulcloud-calendar
           token: ${{ secrets.token }}

--- a/ansible/group_vars/all/h5p-statics.yml
+++ b/ansible/group_vars/all/h5p-statics.yml
@@ -1,0 +1,4 @@
+H5P_STATICFILES_SERVER_IMAGE: docker.io/schulcloud/h5p-staticfiles-server
+H5P_STATICFILES_SERVER_IMAGE_TAG: 0.1.0
+H5P_PORT: 8080
+H5P_PREFIX: h5p

--- a/ansible/group_vars/all/h5p-statics.yml
+++ b/ansible/group_vars/all/h5p-statics.yml
@@ -1,4 +1,0 @@
-H5P_STATICFILES_SERVER_IMAGE: docker.io/schulcloud/h5p-staticfiles-server
-H5P_STATICFILES_SERVER_IMAGE_TAG: 0.1.0
-H5P_PORT: 8080
-H5P_PREFIX: h5p

--- a/ansible/group_vars/all/x_ingress.yml
+++ b/ansible/group_vars/all/x_ingress.yml
@@ -64,7 +64,7 @@ default_ingress:
     serviceName: nuxtclient-svc
     servicePort: "{{ NUXTCLIENT_PORT }}"
   h5p-statics:
-    path: /statics/h5p
+    path: /h5pstatics
     serviceName: h5p-staticfiles-server-svc
     servicePort: "{{ H5P_PORT }}"    
   content:

--- a/ansible/group_vars/all/x_ingress.yml
+++ b/ansible/group_vars/all/x_ingress.yml
@@ -63,6 +63,10 @@ default_ingress:
     path: /nuxtversion
     serviceName: nuxtclient-svc
     servicePort: "{{ NUXTCLIENT_PORT }}"
+  h5pStatics:
+    path: statics/h5p
+    serviceName: h5p-staticfiles-server-svc
+    servicePort: "{{ H5P_PORT }}"    
   content:
     path: /content
     serviceName: nuxtclient-svc

--- a/ansible/group_vars/all/x_ingress.yml
+++ b/ansible/group_vars/all/x_ingress.yml
@@ -63,8 +63,8 @@ default_ingress:
     path: /nuxtversion
     serviceName: nuxtclient-svc
     servicePort: "{{ NUXTCLIENT_PORT }}"
-  h5pStatics:
-    path: statics/h5p
+  h5p-statics:
+    path: /statics/h5p
     serviceName: h5p-staticfiles-server-svc
     servicePort: "{{ H5P_PORT }}"    
   content:

--- a/ansible/group_vars/thr/instance_cfg.yml
+++ b/ansible/group_vars/thr/instance_cfg.yml
@@ -72,3 +72,10 @@ FEATURE_NEXTCLOUD_TEAM_FILES_ENABLED: "false"
 NEXTCLOUD_SCOPES: "openid offline profile email groups"
 
 WITH_TSP: true
+
+# Ingress
+group_ingress:
+  h5p-statics:
+    path: /h5pstatics
+    serviceName: h5p-staticfiles-server-svc
+    servicePort: "{{ H5P_PORT }}" 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -29,6 +29,7 @@
     - superhero-dashboard
     - schulcloud-calendar-core
     - schulcloud-calendar-init
+    - h5p-staticfiles-server-core
     - antivirus_check_service
     - version-aggregator
     - rocketchat

--- a/ansible/playbook_rollout.yml
+++ b/ansible/playbook_rollout.yml
@@ -29,6 +29,7 @@
     - role: schulcloud-server-init
     - role: schulcloud-client-core
     - role: nuxt-client-core
+    - role: h5p-staticfiles-server-core
     - role: superhero-dashboard
     - role: schulcloud-calendar-core
     - role: schulcloud-calendar-init


### PR DESCRIPTION
- add configuration for h5p-staticfiles-server to be deployed on the Cluster

## Links to Tickets or other pull requests:
- [THR-28](https://ticketsystem.dbildungscloud.de/browse/THR-28)
- 

## Changes
the PR necessary to add the deployment for h5p-staticfiles-server Repo to the Cluster 

## New Repo:
[h5p-staticfiles-server](https://github.com/hpi-schul-cloud/h5p-staticfiles-server)

