### PR TITLE
BC-5453 - add URI and version generation for THR dev deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
       - create_branch_identifier
     strategy:
       matrix:
-        tennens: [ brb, default, nbc ]
+        tennens: [ brb, default, nbc, thr ]
     steps:
       - shell: bash
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ on:
 
 
 env:
-  tennens: "brb default nbc"
+  tennens: "brb default nbc thr"
 
 permissions:
   contents: read

--- a/ansible/host_vars/thr_host/cfg.yml
+++ b/ansible/host_vars/thr_host/cfg.yml
@@ -1,0 +1,6 @@
+NOT_AUTHENTICATED_REDIRECT_URL: https://test.schulportal-thueringen.de/cas/login?service=https://{{DOMAIN}}/tsp-login
+TSP_API_BASE_URL: https://test.schulportal-thueringen.de
+ROOT_URL_REDIRECT: https://test.schulportal-thueringen.de/thueringer_schulcloud
+
+#NEXTCLOUD_REDIRECT_URL: https://nextcloud.test.schulcloud-thueringen.de/apps/files/?dir=/
+#NEXTCLOUD_BASE_URL: https://nextcloud.test.schulcloud-thueringen.de

--- a/ansible/host_vars/thr_host/es_cfg.yml
+++ b/ansible/host_vars/thr_host/es_cfg.yml
@@ -1,0 +1,1 @@
+ES_USER: ThuringiaUser


### PR DESCRIPTION
# Description
This PR add the URI and version generation for THR dev deployment.
But not the deployment self only one step at the preparation for it.

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-5453

## Changes
- add thr_host to the ansible/host_vars 
- add Version files generation for thr_host to the Deploy Action
- add URI generation for thr_host to the Deploy Action by add thr tennend


## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
