### PR TITLE
EW-599 Changing deploy condition for erwin idm service monitor

### DIFF
--- a/ansible/roles/erwin-idm/tasks/main.yml
+++ b/ansible/roles/erwin-idm/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: remove Service
   kubernetes.core.k8s:
-    kubeconfig: ~/.kube/config 
+    kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     api_version: v1
     kind: Service
@@ -25,7 +25,7 @@
 
 - name: remove Configmap
   kubernetes.core.k8s:
-    kubeconfig: ~/.kube/config 
+    kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     api_version: v1
     kind: ConfigMap
@@ -42,14 +42,13 @@
 
 - name: remove Secret by 1Password
   kubernetes.core.k8s:
-    kubeconfig: ~/.kube/config 
+    kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     api_version: onepassword.com/v1
     kind: OnePasswordItem
     name: erwinidm-secret
     state: absent
   when: not WITH_ERWINIDM and (ONEPASSWORD_OPERATOR is defined and ONEPASSWORD_OPERATOR|bool)
-
 
 - name: Deployment
   kubernetes.core.k8s:
@@ -60,7 +59,7 @@
 
 - name: remove Deployment
   kubernetes.core.k8s:
-    kubeconfig: ~/.kube/config 
+    kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     api_version: apps/v1
     kind: Deployment
@@ -70,14 +69,14 @@
 
 - name: Ingress
   kubernetes.core.k8s:
-    kubeconfig: ~/.kube/config 
+    kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     template: ingress.yml.j2
   when: WITH_ERWINIDM
 
 - name: remove Ingress
   kubernetes.core.k8s:
-    kubeconfig: ~/.kube/config 
+    kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     api_version: networking.k8s.io/v1
     kind: Ingress
@@ -90,7 +89,7 @@
     kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     template: templates/erwinidm-svc-monitor.yml.j2
-  when: WITH_ERWINIDM and (ERWINIDM_SERVICE_MONITOR is undefined or ERWINIDM_SERVICE_MONITOR is defined and not ERWINIDM_SERVICE_MONITOR) 
+  when: WITH_ERWINIDM and (ERWINIDM_SERVICE_MONITOR is defined and ERWINIDM_SERVICE_MONITOR is true)
 
 - name: remove Service Monitor
   kubernetes.core.k8s:
@@ -100,7 +99,7 @@
     kind: ServiceMonitor
     name: monitoring-prometheus-sc-erwinidm-svc
     state: absent
-  when: not WITH_ERWINIDM and (ERWINIDM_SERVICE_MONITOR is undefined or ERWINIDM_SERVICE_MONITOR is defined and not ERWINIDM_SERVICE_MONITOR)
+  when: not WITH_ERWINIDM and (ERWINIDM_SERVICE_MONITOR is defined and ERWINIDM_SERVICE_MONITOR is true)
 
 - name: Add or Update init scripts Configmap
   kubernetes.core.k8s:
@@ -112,7 +111,7 @@
 
 - name: remove init scripts Configmap
   kubernetes.core.k8s:
-    kubeconfig: ~/.kube/config 
+    kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     api_version: v1
     kind: ConfigMap

--- a/ansible/roles/erwin-idm/tasks/main.yml
+++ b/ansible/roles/erwin-idm/tasks/main.yml
@@ -89,7 +89,7 @@
     kubeconfig: ~/.kube/config
     namespace: "{{ NAMESPACE }}"
     template: templates/erwinidm-svc-monitor.yml.j2
-  when: WITH_ERWINIDM and (ERWINIDM_SERVICE_MONITOR is defined and ERWINIDM_SERVICE_MONITOR is true)
+  when: WITH_ERWINIDM and (ERWINIDM_SERVICE_MONITOR is defined and ERWINIDM_SERVICE_MONITOR)
 
 - name: remove Service Monitor
   kubernetes.core.k8s:
@@ -99,7 +99,7 @@
     kind: ServiceMonitor
     name: monitoring-prometheus-sc-erwinidm-svc
     state: absent
-  when: not WITH_ERWINIDM and (ERWINIDM_SERVICE_MONITOR is defined and ERWINIDM_SERVICE_MONITOR is true)
+  when: not WITH_ERWINIDM and (ERWINIDM_SERVICE_MONITOR is defined and ERWINIDM_SERVICE_MONITOR)
 
 - name: Add or Update init scripts Configmap
   kubernetes.core.k8s:


### PR DESCRIPTION
# Description

The deployment condition for the ErWIn IDM Service Monitor was not correct and always skipped in the deployment. The changes in this PR will fix this behavior. The Service Monitor will always be deployed, if the ErWIn IDM is deployed.

## Links to Tickets or other pull requests

- https://ticketsystem.dbildungscloud.de/browse/EW-599

## Changes

See description.

## Datasecurity

Not affected.

## Deployment

- Fixing deployment for ErWIn IDM Service Monitor

## New Repos, NPM pakages or vendor scripts

Not affected.

## Screenshots of UI changes

Not affected.

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
