### PR TITLE
BC-5456 - add deploy action for dev host

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,5 +1,5 @@
 ---
-name: Deploymen Job for Develop Host 
+name: deploy dev 
 
 on:
   workflow_call:

--- a/.github/workflows/deploy_dev_host.yml
+++ b/.github/workflows/deploy_dev_host.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: deploy for ${{ inputs.tenannt }}
+    name: deploy ${{ inputs.tenannt }}
     steps:
       - uses: actions/download-artifact@v3
       - run: mv */*.tar ./

--- a/.github/workflows/deploy_dev_host.yml
+++ b/.github/workflows/deploy_dev_host.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    name: deploy for ${{ inputs.host_name }}
     steps:
       - uses: actions/download-artifact@v3
       - run: mv */*.tar ./

--- a/.github/workflows/deploy_dev_host.yml
+++ b/.github/workflows/deploy_dev_host.yml
@@ -7,6 +7,9 @@ on:
       host_name:
          required: true
          type: string
+      tenannt:
+         required: true
+         type: string  
     secrets:
       ONEPASSWORD_VAULT:
         required: true
@@ -19,7 +22,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: deploy for ${{ inputs.host_name }}
+    name: deploy for ${{ inputs.tenannt }}
     steps:
       - uses: actions/download-artifact@v3
       - run: mv */*.tar ./

--- a/.github/workflows/deploy_dev_host.yml
+++ b/.github/workflows/deploy_dev_host.yml
@@ -1,5 +1,5 @@
 ---
-name: For dev host 
+name: Deploymen Job for Develop Host 
 
 on:
   workflow_call:

--- a/.github/workflows/deploy_dev_host.yml
+++ b/.github/workflows/deploy_dev_host.yml
@@ -1,0 +1,50 @@
+---
+name: For dev host 
+
+on:
+  workflow_call:
+    inputs:
+      host_name:
+         required: true
+         type: string
+    secrets:
+      ONEPASSWORD_VAULT:
+        required: true
+      KUBECONFIG:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+      - run: mv */*.tar ./
+      - run: find -name "*.tar" -exec tar -xf {} \;
+      - run: tar -cf ansible.tar ansible
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ansible
+          path: ${{github.workspace }}/ansible.tar
+      - shell: bash
+        run: |
+          python3 -m pip install kubernetes
+          
+      - name: 1Password
+        working-directory: ${{github.workspace }}/ansible/group_vars
+        run: |
+          echo "VAULT: ${{ secrets.ONEPASSWORD_VAULT }}" >> develop/dof_deploy.yml
+          echo "ONEPASSWORD_OPERATOR_VAULT: ${{ secrets.ONEPASSWORD_VAULT }}" >> develop/dof_deploy.yml
+          echo "TLS_ENABELD: \"true\"" >> develop/dof_deploy.yml
+      - run: ansible-galaxy install -r ansible/collections/requirements.yml
+      - working-directory: ${{github.workspace }}/ansible/roles/sys
+        run: |
+          mkdir files
+          echo "${{ secrets.KUBECONFIG }}" > files/config
+      - run: ansible-playbook ./playbook.yml --inventory-file hosts --limit "${{ inputs.host_name }}" -e 'ansible_python_interpreter=/usr/bin/python3'
+        working-directory: ${{github.workspace }}/ansible
+      - working-directory: ${{github.workspace }}/ansible/roles/sys/files
+        run: |
+          rm -rf  /config


### PR DESCRIPTION
# Description
Part 1 for split the deployment to dev for each hoast to an one job.
It allow easier to rerun the job for an dev host if the job fail.
In this PR it only add the github action file for the job and not change the deploy job for dev deployment that will be add at the next PR.

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-5456

## Changes
- only add .github/workflows/deploy_dev.yml as file with the new dev deployment job

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
