### PR TITLE
BC-5826 - add deletion of custom resources to delete namespace github action

### DIFF
--- a/.github/workflows/clean_workflow.yml
+++ b/.github/workflows/clean_workflow.yml
@@ -132,7 +132,6 @@ jobs:
           kubectl --kubeconfig=files/config --namespace brb-$branch_identifier delete --ignore-not-found=true --all=true OnePasswordItem
           kubectl --kubeconfig=files/config --namespace nbc-$branch_identifier delete --ignore-not-found=true --all=true OnePasswordItem
           kubectl --kubeconfig=files/config --namespace default-$branch_identifier delete --ignore-not-found=true --all=true OnePasswordItem
-          sleep 30
           kubectl --kubeconfig=files/config delete --ignore-not-found=true ns brb-$branch_identifier nbc-$branch_identifier default-$branch_identifier
       - name: remove kubeconfig
         run: |

--- a/.github/workflows/clean_workflow.yml
+++ b/.github/workflows/clean_workflow.yml
@@ -120,9 +120,19 @@ jobs:
       - run: |
           mkdir files
           echo "${{ secrets.DEV_KUBE_CONFIG }}" > files/config
-      - name: delete namespaces
+      - name: delete custom resources and namespaces 
         run: |
           branch_identifier='${{ needs.create_branch_identifier.outputs.id_branch }}'
+          kubectl --kubeconfig=files/config --namespace brb-$branch_identifier delete --ignore-not-found=true --all=true ScaledObject
+          kubectl --kubeconfig=files/config --namespace nbc-$branch_identifier delete --ignore-not-found=true --all=true ScaledObject
+          kubectl --kubeconfig=files/config --namespace default-$branch_identifier delete --ignore-not-found=true --all=true ScaledObject
+          kubectl --kubeconfig=files/config --namespace brb-$branch_identifier delete --ignore-not-found=true --all=true TriggerAuthentication
+          kubectl --kubeconfig=files/config --namespace nbc-$branch_identifier delete --ignore-not-found=true --all=true TriggerAuthentication
+          kubectl --kubeconfig=files/config --namespace default-$branch_identifier delete --ignore-not-found=true --all=true TriggerAuthentication
+          kubectl --kubeconfig=files/config --namespace brb-$branch_identifier delete --ignore-not-found=true --all=true OnePasswordItem
+          kubectl --kubeconfig=files/config --namespace nbc-$branch_identifier delete --ignore-not-found=true --all=true OnePasswordItem
+          kubectl --kubeconfig=files/config --namespace default-$branch_identifier delete --ignore-not-found=true --all=true OnePasswordItem
+          sleep 30
           kubectl --kubeconfig=files/config delete --ignore-not-found=true ns brb-$branch_identifier nbc-$branch_identifier default-$branch_identifier
       - name: remove kubeconfig
         run: |


### PR DESCRIPTION
# Description
Delete costum resources  before the delete of the namespace.
If the namespace is first deleted then it coud be happend that the delete of it stuck.
See https://cloud.redhat.com/blog/the-hidden-dangers-of-terminating-namespaces for it

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-5826

## Changes


## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
