### PR TITLE
BC-6480 - move audit to deploy group of prod thr, nbc and brb

### DIFF
--- a/.github/workflows/rollout.yml
+++ b/.github/workflows/rollout.yml
@@ -23,7 +23,7 @@ jobs:
       
   ref-audit:
     needs:
-      - approve_ref
+      - approve_prod_stage_2
     uses: ./.github/workflows/host.yml
     with:
       cfg_version: ${{ github.event.inputs.config_tag_name }}


### PR DESCRIPTION
# Description
Move ref-audit to the deploy group from brb, thr and nbc 
But ref-audit is not an prod instance and need to stay at the ref group.

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-6480


## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
