### PR TITLE
BC-5112 - add Annotations to deployment for Restart

### DIFF
--- a/ansible/host_vars/brb_host/cfg.yml
+++ b/ansible/host_vars/brb_host/cfg.yml
@@ -2,3 +2,5 @@ NEXTCLOUD_REDIRECT_URL: https://nextcloud-brb.dbildungscloud.dev/apps/files/?dir
 NEXTCLOUD_BASE_URL: https://nextcloud-brb.dbildungscloud.dev/
 BETTERMARKS_APPS_URL: "https://apps.bettermarks.brb.dbildungscloud.dev"
 BETTERMARKS_SCHOOL_URL: "https://school.bettermarks.brb.dbildungscloud.dev"
+ANNOTATIONS: true
+RELOADER: true

--- a/ansible/roles/clamav/templates/deployment.yml.j2
+++ b/ansible/roles/clamav/templates/deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: clamav-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: clamav
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/clammit/templates/deployment.yml.j2
+++ b/ansible/roles/clammit/templates/deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: clammit-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: clammit
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/dof_etherpad/templates/deployment.yml.j2
+++ b/ansible/roles/dof_etherpad/templates/deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: etherpad-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: etherpad
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/dof_etherpad_nginx/templates/deployment.yml.j2
+++ b/ansible/roles/dof_etherpad_nginx/templates/deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: etherpad-nginx-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: etherpad-nginx
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/dof_mailcatcher/templates/deployment.yml.j2
+++ b/ansible/roles/dof_mailcatcher/templates/deployment.yml.j2
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: mailcatcher-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: mailcatcher
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/dof_mongo/templates/deployment.yml.j2
+++ b/ansible/roles/dof_mongo/templates/deployment.yml.j2
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: mongo-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: mongo
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/dof_postgresql/templates/deployment.yml.j2
+++ b/ansible/roles/dof_postgresql/templates/deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: postgres-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: postgres
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/dof_redis/templates/deployment.yml.j2
+++ b/ansible/roles/dof_redis/templates/deployment.yml.j2
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: redis-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: redis
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/erwin-idm/templates/deployment.yml.j2
+++ b/ansible/roles/erwin-idm/templates/deployment.yml.j2
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: erwinidm-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: erwinidm
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/h5p-proxy/templates/api-h5p-proxy-deployment.yml.j2
+++ b/ansible/roles/h5p-proxy/templates/api-h5p-proxy-deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: api-h5p-proxy-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: api-h5p-proxy
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/hydra/templates/deployment.yml.j2
+++ b/ansible/roles/hydra/templates/deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: hydra-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: hydra
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/ingress/templates/default-backend-404-deployment.yml.j2
+++ b/ansible/roles/ingress/templates/default-backend-404-deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: default-backend-404-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: default-backend-404
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/libreoffice/templates/deployment.yml.j2
+++ b/ansible/roles/libreoffice/templates/deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: libreoffice-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: libreoffice
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/maildrop/templates/deployment.yml.j2
+++ b/ansible/roles/maildrop/templates/deployment.yml.j2
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: maildrop-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: maildrop
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/oidcmock/templates/deployment.yml.j2
+++ b/ansible/roles/oidcmock/templates/deployment.yml.j2
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: oidcmock-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: oidcmock
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/rocketchat/templates/deployment.yml.j2
+++ b/ansible/roles/rocketchat/templates/deployment.yml.j2
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: rocketchat-deployment
   #namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: rocketchat
     app.kubernetes.io/part-of: schulcloud-verbund

--- a/ansible/roles/storage/templates/deployment.yml.j2
+++ b/ansible/roles/storage/templates/deployment.yml.j2
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: storage-deployment
   namespace: {{ NAMESPACE }}
+{% if ANNOTATIONS is defined and ANNOTATIONS|bool %}
+  annotations:
+{% if RELOADER is defined and RELOADER|bool %}
+    reloader.stakater.com/auto: "true"
+{% endif %}
+{% endif %}
   labels:
     app: storage
     app.kubernetes.io/part-of: schulcloud-verbund


### PR DESCRIPTION
# Description
Add annotations to the kubernetes deployments so that they cann automaticly restart by the stakater reloader if configmaps or secrets change 

## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
