### PR TITLE
BC-8207 - Access log off for the nginx who is before etherpad

### DIFF
--- a/ansible/roles/dof_etherpad_nginx/templates/configmap-files.yml.j2
+++ b/ansible/roles/dof_etherpad_nginx/templates/configmap-files.yml.j2
@@ -13,6 +13,7 @@ data:
 
       #charset koi8-r;
       #access_log  /var/log/nginx/host.access.log  main;
+      access_log off;
 
       # Etherpad-Fu
       location /etherpad {

--- a/ansible/roles/dof_etherpad_nginx/templates/configmap-files.yml.j2
+++ b/ansible/roles/dof_etherpad_nginx/templates/configmap-files.yml.j2
@@ -13,6 +13,7 @@ data:
 
       #charset koi8-r;
       #access_log  /var/log/nginx/host.access.log  main;
+      #The Access logs can log the API Key from Etherpad at some points.
       access_log off;
 
       # Etherpad-Fu


### PR DESCRIPTION
# Description

The Access logs can log the API Key from Etherpad at some points.

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-8207

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
