### PR TITLE
BC-8237 - add affinity and anit affinity rules for MongoDB PODs

### DIFF
--- a/ansible/roles/dof_mongo/templates/deployment.yml.j2
+++ b/ansible/roles/dof_mongo/templates/deployment.yml.j2
@@ -92,44 +92,12 @@ spec:
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 9
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/part-of
-                  operator: In
-                  values:
-                  - schulcloud-verbund
-              topologyKey: "kubernetes.io/hostname"
-              namespaceSelector: {}
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-{% if ANIT_AFFINITY_NODEPOOL_ENABLE is defined and ANIT_AFFINITY_NODEPOOL_ENABLE|bool %}
           - weight: 10
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
                 - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - mongo
-              topologyKey: {{ ANIT_AFFINITY_NODEPOOL_TOPOLOGY_KEY }}
-{% endif %}
-          - weight: 20
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - mongo
-              topologyKey: "topology.kubernetes.io/zone"
-          - weight: 10
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
+                  operator: NotIn
                   values:
                   - mongo
               topologyKey: "kubernetes.io/hostname"

--- a/ansible/roles/dof_mongo/templates/deployment.yml.j2
+++ b/ansible/roles/dof_mongo/templates/deployment.yml.j2
@@ -88,3 +88,50 @@ spec:
       - name: mongodb-data-pv
         persistentVolumeClaim:
           claimName: mongo-pvc
+{% if AFFINITY_ENABLE is defined and AFFINITY_ENABLE|bool %}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 9
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/part-of
+                  operator: In
+                  values:
+                  - schulcloud-verbund
+              topologyKey: "kubernetes.io/hostname"
+              namespaceSelector: {}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+{% if ANIT_AFFINITY_NODEPOOL_ENABLE is defined and ANIT_AFFINITY_NODEPOOL_ENABLE|bool %}
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - mongo
+              topologyKey: {{ ANIT_AFFINITY_NODEPOOL_TOPOLOGY_KEY }}
+{% endif %}
+          - weight: 20
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - mongo
+              topologyKey: "topology.kubernetes.io/zone"
+          - weight: 10
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - mongo
+              topologyKey: "kubernetes.io/hostname"
+              namespaceSelector: {}
+{% endif %}


### PR DESCRIPTION
# Description
Somehow to many MongoDB PODs on the same Kubernetes Node produce an not usale CPU load avarage.
To reduce the numbers on MongoDB PODs per Kubernetes Node POD affinity and anit affinity rules where add to the POD tempalte at for the MongoDB PODs.

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-8237

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
