### PR TITLE
BC-8266 - change deploy jobs to Ubuntu 24.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,7 +162,7 @@ jobs:
     needs:
       - create_artifacts_repos
       - create_artifacts_workspaces
-    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@main
+    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@BC-8266
     with:
       host_name: dbc_host
       tenant: dbc
@@ -174,7 +174,7 @@ jobs:
     needs:
       - create_artifacts_repos
       - create_artifacts_workspaces
-    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@main
+    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@BC-8266
     with:
       host_name: nbc_host
       tenant: nbc
@@ -186,7 +186,7 @@ jobs:
     needs:
       - create_artifacts_repos
       - create_artifacts_workspaces
-    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@main
+    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@BC-8266
     with:
       host_name: brb_host
       tenant: brb
@@ -198,7 +198,7 @@ jobs:
     needs:
       - create_artifacts_repos
       - create_artifacts_workspaces
-    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@main
+    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@BC-8266
     with:
       host_name: thr_host
       tenant: thr

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,7 +162,7 @@ jobs:
     needs:
       - create_artifacts_repos
       - create_artifacts_workspaces
-    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@BC-8266
+    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@main
     with:
       host_name: dbc_host
       tenant: dbc
@@ -174,7 +174,7 @@ jobs:
     needs:
       - create_artifacts_repos
       - create_artifacts_workspaces
-    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@BC-8266
+    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@main
     with:
       host_name: nbc_host
       tenant: nbc
@@ -186,7 +186,7 @@ jobs:
     needs:
       - create_artifacts_repos
       - create_artifacts_workspaces
-    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@BC-8266
+    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@main
     with:
       host_name: brb_host
       tenant: brb
@@ -198,7 +198,7 @@ jobs:
     needs:
       - create_artifacts_repos
       - create_artifacts_workspaces
-    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@BC-8266
+    uses: hpi-schul-cloud/dof_app_deploy/.github/workflows/deploy_dev.yml@main
     with:
       host_name: thr_host
       tenant: thr

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -37,7 +37,7 @@ jobs:
 
 
   deploy-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: deploy ${{ inputs.tenant }}
     strategy:
       fail-fast: false

--- a/.github/workflows/host.yml
+++ b/.github/workflows/host.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   set_versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: inputs.execute_group == inputs.host_name || inputs.execute_group == inputs.host_group || inputs.execute_group == inputs.host_stage || inputs.execute_group == 'all'
     concurrency:
       group: ${{ inputs.host_name }}


### PR DESCRIPTION
# Description
At the moment it is posible to get ubuntu 22.04 or ubuntu 24.04 as ubuntu-latest for jobs who ran for github actions.
But there is a major differens how python moduls are install and what thy support so we pin our runner to ubuntu 24,04 for deployment jobs

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-8266

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
