### PR TITLE
BC-8811 - Reconfigure the Probs for etherpad

### DIFF
--- a/ansible/roles/dof_etherpad/templates/deployment.yml.j2
+++ b/ansible/roles/dof_etherpad/templates/deployment.yml.j2
@@ -76,15 +76,25 @@ spec:
           httpGet:
             path: /health
             port: 9001
-          initialDelaySeconds: 60
-          periodSeconds: 10
+          initialDelaySeconds: 0
+          timeoutSeconds: 2
+          periodSeconds: 5
+          failureThreshold: 3
         livenessProbe:
           httpGet:
             path: /health
             port: 9001
-          initialDelaySeconds: 60
+          initialDelaySeconds: 0
+          timeoutSeconds: 2
           periodSeconds: 10
           failureThreshold: 3
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 9001
+          timeoutSeconds: 2
+          failureThreshold:  60
+          periodSeconds: 5
       volumes:
       - name: apikey
         secret:


### PR DESCRIPTION
# Description
Set the initialeDelaySeconds for the readinessProbe and livenessProb to 0 so that is hase not effect and Ansible over wirte it.
Add an startupProbe to the Etherpad deployment so that every 5 seconds for an Failuer Thrashold von 60 will be show if Etherpad is up and runing. So we detect the Earlys timepoint where the user cann access the POD via HTTP. 
We hatte seen at Production that an initial delay off 60 seconds where to low in some cases and we nead an delay like 120 seconds or 180 seconds on wone hand but on the other hand we hade ssen Etherpad PODs who where up in like 30 seconds. 
This Problem had shown that it's easer to add an startupProbe who test it every 5 Seconds for an failure threashod of 60 woud be better, so if the POD is up after 30 second the failure count is at 6 and if the POD is up after 90 seconds the failure count is up to 9. 

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-8811

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
