### PR TITLE
BC-9509 - Replace link to help article on Room Member Page

### DIFF
--- a/ansible/group_vars/brb/instance_cfg.yml
+++ b/ansible/group_vars/brb/instance_cfg.yml
@@ -8,6 +8,7 @@ SC_CONTACT_EMAIL: schul-cloud@bildungsserver.berlin-brandenburg.de
 GLOBAL_ANNOUNCEMENT_TEXT: ""
 GLOBAL_ANNOUNCEMENT_ROLES: teacher,administrator
 TRAINING_URL: "https://ecampus.lisum.de/home"
+ROOM_MEMBER_INFO_URL: "https://brandenburg.cloud/help/confluence/381583517"
 
 SHOW_VERSION: 1
 TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION: opt-in

--- a/ansible/group_vars/dbc/instance_cfg.yml
+++ b/ansible/group_vars/dbc/instance_cfg.yml
@@ -7,6 +7,7 @@ SC_NAV_TITLE: dBildungscloud
 SC_CONTACT_EMAIL: ticketsystem@dbildungscloud.de
 GLOBAL_ANNOUNCEMENT_TEXT: ''
 GLOBAL_ANNOUNCEMENT_ROLES: teacher,administrator
+ROOM_MEMBER_INFO_URL: "https://dbildungscloud.de/help/confluence/381583517"
 
 SHOW_VERSION: 1
 TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION: opt-in

--- a/ansible/group_vars/nbc/instance_cfg.yml
+++ b/ansible/group_vars/nbc/instance_cfg.yml
@@ -8,6 +8,7 @@ SC_CONTACT_EMAIL: ticketsystem@niedersachsen.support
 GLOBAL_ANNOUNCEMENT_TEXT: ""
 GLOBAL_ANNOUNCEMENT_ROLES: teacher,administrator
 TRAINING_URL: "https://openelec.moodle-nds.de/course/index.php?categoryid=53"
+ROOM_MEMBER_INFO_URL: "https://niedersachsen.cloud/help/confluence/381583517"
 
 SHOW_VERSION: 1
 TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION: opt-in
@@ -142,4 +143,3 @@ FEATURE_SCHOOL_TERMS_OF_USE_ENABLED: "true"
 
 # BiLo media metadata sync cronjob
 WITH_MEDIA_METADATA_SYNC: true
-

--- a/ansible/group_vars/thr/instance_cfg.yml
+++ b/ansible/group_vars/thr/instance_cfg.yml
@@ -7,6 +7,7 @@ SC_CONTACT_EMAIL: schulcloud-support@thillm.de
 GLOBAL_ANNOUNCEMENT_TEXT: ''
 GLOBAL_ANNOUNCEMENT_ROLES: teacher,administrator
 TRAINING_URL: "https://www.schulportal-thueringen.de/tio"
+ROOM_MEMBER_INFO_URL: "https://schulcloud-thueringen.de/help/confluence/381583517"
 
 TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION: opt-in
 STUDENT_TEAM_CREATION: "opt-in"


### PR DESCRIPTION
# Description
Currently the link behind "Further information" in the Room Member Administration page links to https://docs.dbildungscloud.de/display/SCDOK/Teameinladung+freigeben. This link needs to be replaced in all instances.

There is a different link for each instance, but it is the same for all languages.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-9509
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes
- adding separate room member info page for each instance
<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
