### PR TITLE
BC-9806 - SJW - display blue status banner (dBC, THR, NBC)

### DIFF
--- a/ansible/group_vars/dbc/instance_cfg.yml
+++ b/ansible/group_vars/dbc/instance_cfg.yml
@@ -5,7 +5,7 @@ SC_TITLE: dBildungscloud
 SC_PRODUCTNAME: dBildungscloud
 SC_NAV_TITLE: dBildungscloud
 SC_CONTACT_EMAIL: ticketsystem@dbildungscloud.de
-GLOBAL_ANNOUNCEMENT_TEXT: ''
+GLOBAL_ANNOUNCEMENT_TEXT: loggedin.text.schoolYearChangeDbc
 GLOBAL_ANNOUNCEMENT_ROLES: teacher,administrator
 ROOM_MEMBER_INFO_URL: "https://dbildungscloud.de/help/confluence/381583517"
 

--- a/ansible/group_vars/nbc/instance_cfg.yml
+++ b/ansible/group_vars/nbc/instance_cfg.yml
@@ -5,8 +5,8 @@ SC_TITLE: Niedersächsische Bildungscloud
 SC_PRODUCTNAME: Niedersächsische Bildungscloud
 SC_NAV_TITLE: Niedersächsische Bildungscloud
 SC_CONTACT_EMAIL: ticketsystem@niedersachsen.support
-GLOBAL_ANNOUNCEMENT_TEXT: ""
-GLOBAL_ANNOUNCEMENT_ROLES: teacher,administrator
+GLOBAL_ANNOUNCEMENT_TEXT: loggedin.text.schoolYearChangeNbc
+GLOBAL_ANNOUNCEMENT_ROLES: administrator
 TRAINING_URL: "https://openelec.moodle-nds.de/course/index.php?categoryid=53"
 ROOM_MEMBER_INFO_URL: "https://niedersachsen.cloud/help/confluence/381583517"
 

--- a/ansible/group_vars/thr/instance_cfg.yml
+++ b/ansible/group_vars/thr/instance_cfg.yml
@@ -4,7 +4,7 @@ SC_TITLE: Thüringer Schulcloud
 SC_PRODUCTNAME: Thüringer Schulcloud
 SC_NAV_TITLE: Thüringer Schulcloud
 SC_CONTACT_EMAIL: schulcloud-support@thillm.de
-GLOBAL_ANNOUNCEMENT_TEXT: ''
+GLOBAL_ANNOUNCEMENT_TEXT: loggedin.text.schoolYearChangeThr
 GLOBAL_ANNOUNCEMENT_ROLES: teacher,administrator
 TRAINING_URL: "https://www.schulportal-thueringen.de/tio"
 ROOM_MEMBER_INFO_URL: "https://schulcloud-thueringen.de/help/confluence/381583517"


### PR DESCRIPTION
# Description
To provide further information for our users (teachers and admins) we want to display the blue status bar again.

Visibility should be set for admins and teachers only. NBC only shows to admins.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-9806

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes
- adding config for dBC, THR and NBC
<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
